### PR TITLE
fix: stringify data when content type is application/json

### DIFF
--- a/packages/taquito-http-utils/src/taquito-http-utils.ts
+++ b/packages/taquito-http-utils/src/taquito-http-utils.ts
@@ -108,7 +108,7 @@ export class HttpBackend {
         method: method ?? 'GET',
         headers: headers,
         // timeout: timeout,
-        body: typeof data === 'object' ? JSON.stringify(data) : data,
+        body: headers['Content-Type'] === 'application/json' ? JSON.stringify(data) : data,
       });
 
       if (!res.ok) {


### PR DESCRIPTION
## Summary

When header Content-Type is `application/json` always JSON.stringify(data)