### PR TITLE
feat: convert async local forge to sync

### DIFF
--- a/packages/taquito-local-forging/src/interface.ts
+++ b/packages/taquito-local-forging/src/interface.ts
@@ -8,5 +8,5 @@ export interface ForgeParams {
 export type ForgeResponse = string; // hex string
 
 export interface Forger {
-  forge(params: ForgeParams): Promise<ForgeResponse>;
+  forge(params: ForgeParams): ForgeResponse;
 }

--- a/packages/taquito-local-forging/src/interface.ts
+++ b/packages/taquito-local-forging/src/interface.ts
@@ -10,3 +10,7 @@ export type ForgeResponse = string; // hex string
 export interface Forger {
   forge(params: ForgeParams): ForgeResponse;
 }
+
+export interface AsyncForger {
+  forge(params: ForgeParams): Promise<ForgeResponse>;
+}

--- a/packages/taquito-local-forging/src/taquito-local-forging.ts
+++ b/packages/taquito-local-forging/src/taquito-local-forging.ts
@@ -38,7 +38,7 @@ export class LocalForger implements Forger {
 
   private codec = getCodec(CODEC.MANAGER, this.protocolHash);
 
-  forge(params: ForgeParams): Promise<string> {
+  forge(params: ForgeParams): string {
     if (validateBlock(params.branch) !== ValidationResult.VALID) {
       throw new InvalidBlockHashError(`The block hash ${params.branch} is invalid`);
     }
@@ -73,11 +73,11 @@ export class LocalForger implements Forger {
       }
     }
     const forged = this.codec.encoder(params).toLowerCase();
-    return Promise.resolve(forged);
+    return forged;
   }
 
-  parse(hex: string): Promise<ForgeParams> {
-    return Promise.resolve(this.codec.decoder(hex) as ForgeParams);
+  parse(hex: string): ForgeParams {
+    return this.codec.decoder(hex) as ForgeParams;
   }
 }
 

--- a/packages/taquito-local-forging/test/taquito-local-forging.spec.ts
+++ b/packages/taquito-local-forging/test/taquito-local-forging.spec.ts
@@ -20,9 +20,9 @@ import { ProtoInferiorTo } from '../src/protocols';
 describe('Forge and parse operations default protocol', () => {
   const localForger = new LocalForger();
   commonCases.forEach(({ name, operation, expected }) => {
-    it(`Common test: ${name}`, async (done) => {
-      const result = await localForger.forge(operation);
-      expect(await localForger.parse(result)).toEqual(expected || operation);
+    it(`Common test: ${name}`, (done) => {
+      const result = localForger.forge(operation);
+      expect(localForger.parse(result)).toEqual(expected || operation);
       done();
     });
   });
@@ -32,7 +32,7 @@ describe('Forge and parse operations default protocol', () => {
 
     const localForger = new LocalForger();
 
-    it('Should throw an error when operation kind is invalid', async () => {
+    it('Should throw an error when operation kind is invalid', () => {
       const operation: any = {
         branch: 'BLzyjjHKEKMULtvkpSHxuZxx6ei6fpntH2BTkYZiLgs8zLVstvX',
         contents: [
@@ -66,7 +66,7 @@ describe('Forge and parse operations default protocol', () => {
       );
     });
 
-    it('Should throw error when parameters are missing', async () => {
+    it('Should throw error when parameters are missing', () => {
       const operation: any = {
         branch: 'BLzyjjHKEKMULtvkpSHxuZxx6ei6fpntH2BTkYZiLgs8zLVstvX',
         contents: [
@@ -99,7 +99,7 @@ describe('Forge and parse operations default protocol', () => {
       );
     });
 
-    it('Should throw error when branch parameter has invalid block hash', async () => {
+    it('Should throw error when branch parameter has invalid block hash', () => {
       const operation: any = {
         branch: 'Invalid_Block_Hash',
         contents: [
@@ -133,7 +133,7 @@ describe('Forge and parse operations default protocol', () => {
       );
     });
 
-    it('Should not throw error when transaction operation does not have a "parameters" property', async () => {
+    it('Should not throw error when transaction operation does not have a "parameters" property', () => {
       const operation: any = {
         branch: 'BLzyjjHKEKMULtvkpSHxuZxx6ei6fpntH2BTkYZiLgs8zLVstvX',
         contents: [
@@ -152,7 +152,7 @@ describe('Forge and parse operations default protocol', () => {
       expect(localForger.forge(operation)).toBeDefined();
     });
 
-    it('Should throw an error when parsing a forged byte with an invalid operation kind', async () => {
+    it('Should throw an error when parsing a forged byte with an invalid operation kind', () => {
       const invalidForged =
         'a99b946c97ada0f42c1bdeae0383db7893351232a832d00d0cd716eb6f66e5614c0035e993d8c7aaa42b5e3ccd86a33390ececc73abd904e010a0ae807000035e993d8c7aaa42b5e3ccd86a33390ececc73abd00';
       expect(() => {
@@ -174,7 +174,7 @@ describe('Forge and parse operations default protocol', () => {
       );
     });
 
-    it(`Verify getCodec for CODEC.SECRET`, async (done) => {
+    it(`Verify getCodec for CODEC.SECRET`, (done) => {
       const codec = CODEC.SECRET;
       const myGetCodec = getCodec(codec, ProtocolsHash.PtKathman);
       const consumer = myGetCodec.decoder(hexToParse);
@@ -183,7 +183,7 @@ describe('Forge and parse operations default protocol', () => {
       done();
     });
 
-    it(`Verify getCodec for CODEC.RAW`, async (done) => {
+    it(`Verify getCodec for CODEC.RAW`, (done) => {
       const codec = CODEC.RAW;
       const myGetCodec = getCodec(codec, ProtocolsHash.PtKathman);
       const consumer = myGetCodec.decoder(hexToParse);
@@ -192,7 +192,7 @@ describe('Forge and parse operations default protocol', () => {
       done();
     });
 
-    it(`Verify getCodec for CODEC.OP_DELEGATION`, async (done) => {
+    it(`Verify getCodec for CODEC.OP_DELEGATION`, (done) => {
       const codec = CODEC.OP_DELEGATION;
       const myGetCodec = getCodec(codec, ProtocolsHash.PtKathman);
       const _consumer = expect(() => myGetCodec.decoder(hexToParse)).toThrow(
@@ -201,7 +201,7 @@ describe('Forge and parse operations default protocol', () => {
       done();
     });
 
-    it(`Verify Arrow Function for CODEC.OP_SEED_NONCE_REVELATION`, async (done) => {
+    it(`Verify Arrow Function for CODEC.OP_SEED_NONCE_REVELATION`, (done) => {
       const codec = CODEC.OP_SEED_NONCE_REVELATION;
       const myGetCodec = getCodec(codec, ProtocolsHash.PtKathman);
       const gotCodec = myGetCodec.decoder(hexToParse);
@@ -216,7 +216,7 @@ describe('Forge and parse operations default protocol', () => {
       done();
     });
 
-    it(`Verify Arrow Functions for CODEC.SECRET is toHexString(val.consume(20))`, async (done) => {
+    it(`Verify Arrow Functions for CODEC.SECRET is toHexString(val.consume(20))`, (done) => {
       const codec = CODEC.SECRET;
       const myGetCodec = getCodec(codec, ProtocolsHash.PtKathman);
       const encodeCodec = myGetCodec.encoder('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
@@ -228,7 +228,7 @@ describe('Forge and parse operations default protocol', () => {
       done();
     });
 
-    it(`Verify Arrow Function for CODEC.RAW is toHexString(val.consume(32)),`, async (done) => {
+    it(`Verify Arrow Function for CODEC.RAW is toHexString(val.consume(32)),`, (done) => {
       const codec = CODEC.RAW;
       const myGetCodec = getCodec(codec, ProtocolsHash.PtKathman);
       const encodeCodec = myGetCodec.encoder('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
@@ -242,7 +242,7 @@ describe('Forge and parse operations default protocol', () => {
       done();
     });
 
-    it(`Verify Arrow Function for CODEC.OP_ACTIVATE_ACCOUNT`, async (done) => {
+    it(`Verify Arrow Function for CODEC.OP_ACTIVATE_ACCOUNT`, (done) => {
       const codec = CODEC.OP_ACTIVATE_ACCOUNT;
       const myGetCodec = getCodec(codec, ProtocolsHash.PtKathman);
       const gotCodec = myGetCodec.decoder(hexToParse);
@@ -259,7 +259,7 @@ describe('Forge and parse operations default protocol', () => {
       done();
     });
 
-    it(`Test getCodec to verify codec Manager sent to decoders is defined`, async (done) => {
+    it(`Test getCodec to verify codec Manager sent to decoders is defined`, (done) => {
       const myGetCodec = getCodec(CODEC.MANAGER, ProtocolsHash.PtKathman).decoder(
         '7c842c15c8b0c8fd228e6cb5302a50201f41642dd36b699003fb3c857920bc9d'
       );
@@ -286,8 +286,8 @@ describe('Forge and parse operations default protocol', () => {
     });
 
     describe('Verify forged bytes of Smart Rollup operations', () => {
-      it('forged bytes smart_rollup_originate should match', async () => {
-        const forged = await localForger.forge({
+      it('forged bytes smart_rollup_originate should match', () => {
+        const forged = localForger.forge({
           branch: 'BLxGBu48ybnWvZoaVLyXV4XVnhdeDc9V2NcB9wsegQniza6mxvX',
           contents: [
             {
@@ -318,8 +318,8 @@ describe('Forge and parse operations default protocol', () => {
         expect(forged).toContain('000000020369');
       });
 
-      it('forged bytes smart_rollup_add_messages should match', async () => {
-        const forged = await localForger.forge({
+      it('forged bytes smart_rollup_add_messages should match', () => {
+        const forged = localForger.forge({
           branch: 'BLxGBu48ybnWvZoaVLyXV4XVnhdeDc9V2NcB9wsegQniza6mxvX',
           contents: [
             {
@@ -347,8 +347,8 @@ describe('Forge and parse operations default protocol', () => {
         );
       });
 
-      it('forged bytes smart_rollup_execute_outbox_message should match', async () => {
-        const forged = await localForger.forge({
+      it('forged bytes smart_rollup_execute_outbox_message should match', () => {
+        const forged = localForger.forge({
           branch: 'BLxGBu48ybnWvZoaVLyXV4XVnhdeDc9V2NcB9wsegQniza6mxvX',
           contents: [
             {

--- a/packages/taquito/src/context.ts
+++ b/packages/taquito/src/context.ts
@@ -1,6 +1,6 @@
 import { RpcClient, RpcClientInterface } from '@exodus/taquito-rpc';
 import { Protocols } from './constants';
-import { Forger } from '@exodus/taquito-local-forging';
+import { AsyncForger } from '@exodus/taquito-local-forging';
 import { Injector } from './injector/interface';
 import { RpcInjector } from './injector/rpc-injector';
 import { Signer } from './signer/interface';
@@ -45,7 +45,7 @@ export const defaultConfigConfirmation: ConfigConfirmation = {
  */
 export class Context {
   private _rpcClient: RpcClientInterface;
-  private _forger: Forger;
+  private _forger: AsyncForger;
   private _parser: ParserProvider;
   private _injector: Injector;
   private _walletProvider: WalletProvider;
@@ -69,7 +69,7 @@ export class Context {
     public readonly _config = new BehaviorSubject({
       ...defaultConfigConfirmation,
     }),
-    forger?: Forger,
+    forger?: AsyncForger,
     injector?: Injector,
     packer?: Packer,
     wallet?: WalletProvider,
@@ -133,7 +133,7 @@ export class Context {
     return this._forger;
   }
 
-  set forger(value: Forger) {
+  set forger(value: AsyncForger) {
     this._forger = value;
   }
 

--- a/packages/taquito/src/forger/composite-forger.ts
+++ b/packages/taquito/src/forger/composite-forger.ts
@@ -1,4 +1,4 @@
-import { Forger, ForgeParams, ForgeResponse } from '@exodus/taquito-local-forging';
+import { AsyncForger, ForgeParams, ForgeResponse } from '@exodus/taquito-local-forging';
 
 /**
  *  @category Error
@@ -22,8 +22,8 @@ export class UnspecifiedForgerError extends Error {
   }
 }
 
-export class CompositeForger implements Forger {
-  constructor(private forgers: Forger[]) {
+export class CompositeForger implements AsyncForger {
+  constructor(private forgers: AsyncForger[]) {
     if (forgers.length === 0) {
       throw new UnspecifiedForgerError();
     }

--- a/packages/taquito/src/forger/rpc-forger.ts
+++ b/packages/taquito/src/forger/rpc-forger.ts
@@ -1,7 +1,7 @@
-import { Forger, ForgeParams, ForgeResponse } from '@exodus/taquito-local-forging';
+import { AsyncForger, ForgeParams, ForgeResponse } from '@exodus/taquito-local-forging';
 import { Context } from '../context';
 
-export class RpcForger implements Forger {
+export class RpcForger implements AsyncForger {
   constructor(private context: Context) {}
 
   forge({ branch, contents }: ForgeParams): Promise<ForgeResponse> {

--- a/packages/taquito/src/forger/taquito-local-forger.ts
+++ b/packages/taquito/src/forger/taquito-local-forger.ts
@@ -1,6 +1,6 @@
 import {
   LocalForger,
-  Forger,
+  AsyncForger,
   ForgeParams,
   ForgeResponse,
   ProtocolsHash,
@@ -8,7 +8,7 @@ import {
 import { Protocols } from '../constants';
 import { Context } from '../context';
 
-export class TaquitoLocalForger implements Forger {
+export class TaquitoLocalForger implements AsyncForger {
   constructor(private context: Context) {}
 
   private async getNextProto(): Promise<ProtocolsHash> {

--- a/packages/taquito/src/taquito.ts
+++ b/packages/taquito/src/taquito.ts
@@ -4,7 +4,7 @@
  */
 
 import { RpcClient, RpcClientInterface } from '@exodus/taquito-rpc';
-import { Forger } from '@exodus/taquito-local-forging';
+import { AsyncForger } from '@exodus/taquito-local-forging';
 import { RPCBatchProvider } from './batch/rpc-batch-provider';
 import { Protocols } from './constants';
 import { ConfigConfirmation, Context, TaquitoProvider } from './context';
@@ -32,7 +32,7 @@ import { ParserProvider } from './parser/interface';
 import { MichelCodecParser } from './parser/michel-codec-parser';
 
 export { MichelsonMap, UnitValue } from '@exodus/taquito-michelson-encoder';
-export { Forger, ForgeParams, ForgeResponse } from '@exodus/taquito-local-forging';
+export { AsyncForger, ForgeParams, ForgeResponse } from '@exodus/taquito-local-forging';
 export * from './constants';
 export * from './context';
 export { TaquitoProvider } from './context';
@@ -71,7 +71,7 @@ export { TaquitoLocalForger } from './forger/taquito-local-forger';
 export * from './prepare';
 
 export interface SetProviderOptions {
-  forger?: Forger;
+  forger?: AsyncForger;
   wallet?: WalletProvider;
   rpc?: string | RpcClientInterface;
   readProvider?: TzReadProvider;


### PR DESCRIPTION
## Summary
- Convert async forge operations to synchronous ones in the LocalForger.
- Create a new `AsyncForger` interface for the parts of the code that need it like the RPC Forger.